### PR TITLE
Bluebird compatiblity

### DIFF
--- a/src/Ext/Handlers/Web.js
+++ b/src/Ext/Handlers/Web.js
@@ -539,6 +539,8 @@ class Web extends Handler{
         else{
           responseCallback(null, result, req, res, next);
         }
+        // runaway promise
+        return null;
       }).catch((err) => {
         if (render){
           web.output(err);

--- a/src/Handler.js
+++ b/src/Handler.js
@@ -252,7 +252,10 @@ class Handler{
     // the session finalization runs in parallel, since it does secondary tasks
     // (such as clean-up, logging, etc...) there is no need to await for that
     if (finalizeSession){
-      this.session().finalize().then().catch((err) => {
+      this.session().finalize().then(() => {
+        // runaway promise
+        return null;
+      }).catch((err) => {
         this._emitOutputError(err);
       });
     }


### PR DESCRIPTION
Improved compatibility with bluebird by avoiding a warning caused when 'then' returns undefined