### PR TITLE
using async in examples

### DIFF
--- a/src/Action.js
+++ b/src/Action.js
@@ -20,7 +20,7 @@ class InvalidActionError extends Error{
  * An action is used to perform an evaluation.
  *
  * By implementing an evaluation through an action, the evaluation is wrapped by an
- * interface that can be triggered from many different forms ({@link Handler}).
+ * interface that can be triggered from different domains ({@link Handler}).
  *
  * ```
   * class HelloWorld extends Mebo.Action{

--- a/src/Action.js
+++ b/src/Action.js
@@ -20,18 +20,7 @@ class InvalidActionError extends Error{
  * An action is used to perform an evaluation.
  *
  * By implementing an evaluation through an action, the evaluation is wrapped by an
- * interface that can be triggered from different domains ({@link Handler}).
- *
- * ```
-  * class HelloWorld extends Mebo.Action{
- *   async _perform(data){
- *     return 'Hello World';
- *   }
- * }
- *
- * const action = new HelloWorld();
- * action.run().then(...) //  HelloWorld
- * ```
+ * agnostic interface which can be triggered through different domains ({@link Handler}).
  *
  * The data used to perform an evaluation is held by inputs ({@link Action.createInput}).
  * These inputs can be widely configured to enforce quality control via properties.
@@ -41,12 +30,11 @@ class InvalidActionError extends Error{
  * class HelloWorld extends Mebo.Action{
  *   constructor(){
  *     super();
- *     this.createInput('repeat: numeric', {max: 100});
+ *     this.createInput('repeat: numeric', {max: 100}); <- input
  *   }
  *
  *   async _perform(data){
- *     const result = 'HelloWorld '.repeat(data.repeat);
- *     return result;
+ *     return 'HelloWorld '.repeat(data.repeat);
  *   }
  * }
  *
@@ -55,7 +43,7 @@ class InvalidActionError extends Error{
  * action.run().then(...) //  HelloWorld HelloWorld HelloWorld
  * ```
  *
- * An evaluation is triggered through {@link Action.run} which internally calls
+ * An action is triggered through {@link Action.run} which internally calls
  * {@link Action._perform}. Use `_perform` to implement the evaluation of your action.
  * Also, you can implement {@link Action._finalize} to execute secondary routines.
  *
@@ -636,8 +624,8 @@ class Action{
    * @abstract
    * @protected
    */
-  _perform(data){
-    return Promise.reject(new Error('Not implemented error!'));
+  async _perform(data){
+    throw new Error('Not implemented error!');
   }
 
   /**
@@ -655,8 +643,8 @@ class Action{
    *
    * @protected
    */
-  _finalize(err, value){
-    return Promise.resolve(null);
+  async _finalize(err, value){
+    return null;
   }
 
   /**

--- a/src/Handler.js
+++ b/src/Handler.js
@@ -54,7 +54,7 @@ const _metadata = Symbol('metadata');
  *      // ...
  *    }
  *
- *    _finalize(err, value){
+ *    async _finalize(err, value){
  *
  *      // change 'name' for the registration name of the handler you
  *      // want to define the write options
@@ -67,8 +67,6 @@ const _metadata = Symbol('metadata');
  *            someWriteOption: 10,
  *        });
  *      }
- *
- *      super._finalize(err, value);
  *    }
  * }
  * ```

--- a/src/Handlers/Cli.js
+++ b/src/Handlers/Cli.js
@@ -184,7 +184,7 @@ class Cli extends Handler{
    *     this.createInput('name: text');
    *     this.createInput('myOtherInput?: numeric');
    *  }
-   *  _perform(data){
+   *  async _perform(data){
    *    // ...
    *  }
    * }

--- a/src/Metadata.js
+++ b/src/Metadata.js
@@ -34,11 +34,11 @@ const _collection = Symbol('collection');
  *      this.setMeta('$webUploadDirectory', '/tmp/customUploadDir');
  *    }
  *
- *    _perform(data){
+ *    async _perform(data){
  *      // ...
  *    }
  *
- *    _finalize(err, value){
+ *    async _finalize(err, value){
  *      // defining a custom header that only affects the web handler
  *      // this call could be done inside of the _perform method. However, we
  *      // are defining it inside of the _finalize to keep _perform as
@@ -52,8 +52,6 @@ const _collection = Symbol('collection');
  *          someOption: 'foo',
  *        });
  *      }
- *
- *      return super._finalize(err, value);
  *    }
  * }
  * ```
@@ -73,11 +71,11 @@ const _collection = Symbol('collection');
  *      this.setMeta('handler.web.readOptions.uploadDirectory', '/tmp/customUploadDir');
  *    }
  *
- *    _perform(data){
+ *    async _perform(data){
  *      // ...
  *    }
  *
- *    _finalize(err, value){
+ *    async _finalize(err, value){
  *
  *      if (!err){
  *        // location (not recommended, see option var)
@@ -85,8 +83,6 @@ const _collection = Symbol('collection');
  *          someOption: 'foo',
  *        });
  *      }
- *
- *      return super._finalize(err, value);
  *    }
  * }
  * ```

--- a/src/Writers/CliOutput.js
+++ b/src/Writers/CliOutput.js
@@ -32,7 +32,7 @@ const _stderr = Symbol('stderr');
  *      // ...
  *    }
  *
- *    _finalize(err, value){
+ *    async _finalize(err, value){
  *      // defining a custom result that only affects the web handler
  *      // this call could be done inside of the _perform method. However, we
  *      // are defining it inside of the _finalize to keep _perform as
@@ -45,8 +45,6 @@ const _stderr = Symbol('stderr');
  *              message: 'My custom cli result!',
  *          });
  *      }
- *
- *      return super._finalize(err, value);
  *    }
  *
  *    // ...

--- a/src/Writers/WebResponse.js
+++ b/src/Writers/WebResponse.js
@@ -32,7 +32,7 @@ const _response = Symbol('response');
  *      // ...
  *    }
  *
- *    _finalize(err, value){
+ *    async _finalize(err, value){
  *      // defining a custom result that only affects the web handler
  *      // this call could be done inside of the _perform method. However, we
  *      // are defining it inside of the _finalize to keep _perform as
@@ -45,8 +45,6 @@ const _response = Symbol('response');
  *              message: 'My custom web result!',
  *          });
  *      }
- *
- *      return super._finalize(err, value);
  *    }
  *
  *    // ...
@@ -88,7 +86,7 @@ const _response = Symbol('response');
  * ```
  * // defining 'Content-Type' header
  * class MyAction extends Mebo.Action{
- *    _perform(data){
+ *    async _perform(data){
  *
  *      // 'Content-Type' header
  *      this.setMeta('$webHeaders', {


### PR DESCRIPTION
This pull requested only changes the documentation by including async in the examples used by the documentation about _perform and _finalize.

- Using async in examples for _perform and _finalize