### PR TITLE
changed cli init signature

### DIFF
--- a/src/Handlers/Cli.js
+++ b/src/Handlers/Cli.js
@@ -177,6 +177,8 @@ class Cli extends Handler{
    * ```
    * const Mebo = require('mebo');
    *
+   * @Mebo.grant('cli', 'cli.default', {initName: 'default'})
+   * @Mebo.register('cli.default')
    * class Default extends Mebo.Action{
    *
    *  constructor(){
@@ -189,8 +191,6 @@ class Cli extends Handler{
    *  }
    * }
    *
-   * Mebo.Action.register(Default, 'cli.default');
-   * Mebo.Handler.grantAction('cli', 'cli.default', {initName: 'default'});
    * ```
    *
    * *`index.js`:*
@@ -219,26 +219,25 @@ class Cli extends Handler{
    * ```
    * node myFile.js --cli myCli --arg-a=1 --arg-b=2
    * ```
-   *
-   * @param {string} defaultCliName - default name used when none
-   * cli is specified through `--cli <name>`
    * @param {Object} options - plain object containing custom options
+   * @param {string} [options.defaultCliName] - default name used when none
+   * cli is specified through `--cli <name>`
    * @param {Array<string>} [options.argv] - custom list of arguments, if not specified
    * it uses the `process.argv` (this information is passed to the creation of cli handler)
    * @param {stream} [options.stdout] - custom writable stream, if not specified it uses
    * `process.stdout` (this information is passed to the creation of cli handler)
    * @param {stream} [options.stderr] - custom writable stream, if not specified it uses
    * `process.stderr` (this information is passed to the creation of cli handler)
-   * @param {function} [options.initializedCallback] - callback executed when the
-   * initialization is done, it passes the value used by the output
+   * @param {function} [options.finalizeCallback] - callback executed after the
+   * initialization, it passes the value used by the output
    */
   static init(
-    defaultCliName,
     {
+      defaultCliName='',
       argv=process.argv,
       stdout=process.stdout,
       stderr=process.stderr,
-      initializedCallback=null,
+      finalizeCallback=null,
     }={},
   ){
 
@@ -253,8 +252,8 @@ class Cli extends Handler{
         handler.output(value);
       }
       finally{
-        if (initializedCallback){
-          initializedCallback(value);
+        if (finalizeCallback){
+          finalizeCallback(value);
         }
       }
     };

--- a/test/Handlers/Cli/generic.js
+++ b/test/Handlers/Cli/generic.js
@@ -85,8 +85,8 @@ describe('Cli Generic:', () => {
   it('Should fail to create an app that contains a non granted action', () => {
     const errStream = new WriteStream();
     Mebo.Handlers.Cli.init(
-      'invalidCli',
       {
+        defaultCliName: 'invalidCli',
         stderr: errStream,
       },
     );

--- a/test/Handlers/Cli/init.js
+++ b/test/Handlers/Cli/init.js
@@ -47,26 +47,28 @@ describe('Cli Init:', () => {
   it('Should initialize the app', (done) => {
 
     const options = {};
+    options.defaultCliName = 'multiply';
     options.argv = ['executable', 'file', '--cli', '--help'];
     options.stdout = new WriteStream();
     options.stderr = new WriteStream();
-    options.initializedCallback = ((result) => {
+    options.finalizeCallback = ((result) => {
       done();
     });
 
-    Cli.init('multiply', options);
+    Cli.init(options);
   });
 
   it('Should initialize the app2', (done) => {
 
     const options = {};
+    options.defaultCliName = 'myCli';
     options.argv = ['executable', 'file', '--cli', 'multi', '--a', '1', '--b', '2'];
     options.stdout = new WriteStream();
     options.stderr = new WriteStream();
-    options.initializedCallback = ((result) => {
+    options.finalizeCallback = ((result) => {
       done();
     });
 
-    Mebo.Handler.get('cli').init('myCli', options);
+    Mebo.Handler.get('cli').init(options);
   });
 });


### PR DESCRIPTION
This pull request changes a little bit the signature of the cli.init by making the optional defaultCliName as optional and renaming initializedCallback to finalizeCallback.

- Cli.init defaultCliName argument is now optional
- Cli.init renamed option initializedCallback to finalizeCallback