### PR TITLE
Using literal notation to create empty objects

### DIFF
--- a/src/Action.js
+++ b/src/Action.js
@@ -687,7 +687,7 @@ class Action{
   async _execute(){
     let result = null;
 
-    const data = Object.create(null);
+    const data = {};
     const readOnlyOriginalValues = new Map();
 
     // making inputs read-only during the execution, otherwise it would be very dangerous

--- a/src/Handlers/Web.js
+++ b/src/Handlers/Web.js
@@ -434,12 +434,12 @@ class Web extends Handler{
 
     // storing the action under the auxiliary data struct 'action method to webfied index'
     if (!(actionName in this[_actionMethodToWebfiedIndex])){
-      this[_actionMethodToWebfiedIndex][actionName] = Object.create(null);
+      this[_actionMethodToWebfiedIndex][actionName] = {};
     }
 
     // adding the routes
     for (const addMethod of methods){
-      const webfiedAction = Object.create(null);
+      const webfiedAction = {};
       webfiedAction.actionName = actionName;
       webfiedAction.method = addMethod;
       webfiedAction.auth = auth;

--- a/src/Inputs/Url.js
+++ b/src/Inputs/Url.js
@@ -111,7 +111,7 @@ class Url extends BaseText{
 
       this._parseUrl(at);
 
-      const options = Object.create(null);
+      const options = {};
       options.method = 'HEAD';
       options.protocol = this._getFromCache('urlParsed', at).protocol;
       options.host = this._getFromCache('urlParsed', at).hostname;
@@ -129,7 +129,7 @@ class Url extends BaseText{
         const request = httpModule.request(options, (response) => {
 
           let errorStatus = null;
-          let headers = Object.create(null);
+          let headers = {};
           if (response.statusCode === 200){
             headers = response.headers;
           }

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -198,7 +198,7 @@ class Reader{
       await this._parse();
     }
 
-    const result = Object.create(null);
+    const result = {};
     const action = this.action();
     const session = action.session();
     for (const inputName in this[_result]){

--- a/src/Readers/CliArgs.js
+++ b/src/Readers/CliArgs.js
@@ -116,7 +116,7 @@ class CliArgs extends Reader{
     const helpElements = await this.constructor._helpElements(inputList);
     const helpString = await this._renderHelp(helpElements);
 
-    let parsedArgs = Object.create(null);
+    let parsedArgs = {};
     // it thrown an exception if something went wrong (like missing a required parameter)
     try{
       parsedArgs = neodoc.run(helpString, {
@@ -148,7 +148,7 @@ class CliArgs extends Reader{
     }
 
     const alreadyParsed = [];
-    const result = Object.create(null);
+    const result = {};
 
     // collecting the input values
     for (const elementName in parsedArgs){
@@ -262,7 +262,7 @@ class CliArgs extends Reader{
 
       const elementType = input.property('elementType');
 
-      const inputData = Object.create(null);
+      const inputData = {};
       inputData.description = descriptions[currentIndex];
       inputData.elementDisplay = this._elementDisplay(argName, input);
       inputData.usageDisplay = this._usageDisplay(argName, input);
@@ -488,8 +488,8 @@ class CliArgs extends Reader{
   _buildUsage(elements){
     let output = `Usage: ${this.executableName(true)} `;
 
-    const requiredArguments = Object.create(null);
-    const optionalArguments = Object.create(null);
+    const requiredArguments = {};
+    const optionalArguments = {};
     const requiredOptions = Object.keys(elements.option).filter(x => elements.option[x].required);
     let requiredArgumentsOrder = [];
     let optionalArgumentsOrder = [];
@@ -606,7 +606,7 @@ class CliArgs extends Reader{
    */
   static _buildColumns(elements){
     let columns = '\n';
-    const elementTypeDisplayName = Object.create(null);
+    const elementTypeDisplayName = {};
     elementTypeDisplayName.option = 'Options:';
     elementTypeDisplayName.argument = 'Arguments:';
 
@@ -651,7 +651,7 @@ class CliArgs extends Reader{
    * @private
    */
   static _computeElementsWidth(elements){
-    const elementTypeWidth = Object.create(null);
+    const elementTypeWidth = {};
     for (const elementType in elements){
       for (const inputName in elements[elementType]){
         elementTypeWidth[elementType] = Math.max(elementTypeWidth[elementType] || 0,

--- a/src/Readers/WebRequest.js
+++ b/src/Readers/WebRequest.js
@@ -171,7 +171,7 @@ class WebRequest extends Reader{
    * @protected
    */
   async _perform(inputList){
-    const result = Object.create(null);
+    const result = {};
     const request = this.request();
 
     // when help is requested
@@ -349,7 +349,7 @@ class WebRequest extends Reader{
    */
   _normalizeFieldMultipleValues(bodyFields){
 
-    const multipleValueFields = Object.create(null);
+    const multipleValueFields = {};
 
     for (const inputName in bodyFields.fields){
 
@@ -463,7 +463,7 @@ class WebRequest extends Reader{
           return;
         }
 
-        const result = Object.create(null);
+        const result = {};
         result.files = formFiles;
         result.fields = formFields;
 

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -66,7 +66,7 @@ class Settings{
   }
 }
 
-Settings[_data] = Object.create(null);
+Settings[_data] = {};
 
 // default settings:
 // apiVersion

--- a/src/Utils/LruCache.js
+++ b/src/Utils/LruCache.js
@@ -136,7 +136,7 @@ class LruCache{
       });
     }
 
-    const resultHolder = Object.create(null);
+    const resultHolder = {};
     resultHolder.memorySize = sizeof(value);
     resultHolder.data = value;
 


### PR DESCRIPTION
This pull request brings a small change about how empty objects are created in favor of readability by replacing all Object.create(null) to {}.

- Using literal notation to create empty objects